### PR TITLE
Return void in set method

### DIFF
--- a/src/Proxy.php
+++ b/src/Proxy.php
@@ -61,9 +61,8 @@ final class Proxy
      * @param mixed $value
      *
      * @throws ReflectionException
-     * @return $this
      */
-    public function __set(string $key, $value): self
+    public function __set(string $key, $value): void
     {
         $property = new ReflectionProperty($this->class, $key);
 
@@ -74,8 +73,6 @@ final class Proxy
         $property->isStatic()
             ? $property->setValue($value)
             : $property->setValue($this->object, $value);
-
-        return $this;
     }
 
     /**


### PR DESCRIPTION
While testing with PHP8 a Fatal error "Return type must be void" was thrown for the __set method.
This fix should not impact previous PHP versions.